### PR TITLE
Render site the same in Chrome with or without dark mode enabled

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,11 +2,7 @@
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color-scheme: only light;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
I suggest this PR so as to enforce one style, which could help make it easier at this time to test new functions and look at SVG rendering later on within FIrefox.

Having dark mode turned on at a system level makes it difficult to see some elements of the site that are rendering black on a black background.

Disabling dark mode at a system level renders the site as shown in meeting demos. However, disabling dark mode within Chrome developer flags does not work, and applying different policies via `color-scheme` CSS were ignored when flags were disabled.

Using the `color-scheme: only light` style and removing background and text color styles appears to work with dark mode enabled, however, if a "light" style (i.e., dark text on light background) is acceptable.